### PR TITLE
Allow passing a custom widget to form.MoneyField

### DIFF
--- a/money/contrib/django/forms/fields.py
+++ b/money/contrib/django/forms/fields.py
@@ -9,13 +9,13 @@ class MoneyField(forms.MultiValueField):
     A MultiValueField to represent both the quantity of money and the currency
     """
 
-    def __init__(self, choices=None, decimal_places=2, max_digits=12, hide_currency=False, *args, **kwargs):
+    def __init__(self, choices=None, decimal_places=2, max_digits=12, widget=None, *args, **kwargs):
         # Note that we catch args and kwargs that must only go to one field
         # or the other. The rest of them pass onto the decimal field.
         choices = choices or [
             (c.code, u"{0} - {1}".format(c.code, c.name),) for i, c in sorted(CURRENCY.items()) if c.code != u'XXX']
 
-        self.widget = CurrencySelectWidget(choices, hide_currency=hide_currency)
+        self.widget = widget() if widget is not None else CurrencySelectWidget(choices)
 
         fields = (
             forms.DecimalField(

--- a/money/contrib/django/forms/fields.py
+++ b/money/contrib/django/forms/fields.py
@@ -9,13 +9,13 @@ class MoneyField(forms.MultiValueField):
     A MultiValueField to represent both the quantity of money and the currency
     """
 
-    def __init__(self, choices=None, decimal_places=2, max_digits=12, *args, **kwargs):
+    def __init__(self, choices=None, decimal_places=2, max_digits=12, hide_currency_select=False, *args, **kwargs):
         # Note that we catch args and kwargs that must only go to one field
         # or the other. The rest of them pass onto the decimal field.
         choices = choices or [
             (c.code, u"{0} - {1}".format(c.code, c.name),) for i, c in sorted(CURRENCY.items()) if c.code != u'XXX']
 
-        self.widget = CurrencySelectWidget(choices)
+        self.widget = CurrencySelectWidget(choices, hide_currency_select=hide_currency_select)
 
         fields = (
             forms.DecimalField(

--- a/money/contrib/django/forms/fields.py
+++ b/money/contrib/django/forms/fields.py
@@ -9,13 +9,13 @@ class MoneyField(forms.MultiValueField):
     A MultiValueField to represent both the quantity of money and the currency
     """
 
-    def __init__(self, choices=None, decimal_places=2, max_digits=12, hide_currency_select=False, *args, **kwargs):
+    def __init__(self, choices=None, decimal_places=2, max_digits=12, hide_currency=False, *args, **kwargs):
         # Note that we catch args and kwargs that must only go to one field
         # or the other. The rest of them pass onto the decimal field.
         choices = choices or [
             (c.code, u"{0} - {1}".format(c.code, c.name),) for i, c in sorted(CURRENCY.items()) if c.code != u'XXX']
 
-        self.widget = CurrencySelectWidget(choices, hide_currency_select=hide_currency_select)
+        self.widget = CurrencySelectWidget(choices, hide_currency=hide_currency)
 
         fields = (
             forms.DecimalField(

--- a/money/contrib/django/forms/fields.py
+++ b/money/contrib/django/forms/fields.py
@@ -15,7 +15,7 @@ class MoneyField(forms.MultiValueField):
         choices = choices or [
             (c.code, u"{0} - {1}".format(c.code, c.name),) for i, c in sorted(CURRENCY.items()) if c.code != u'XXX']
 
-        self.widget = widget() if widget is not None else CurrencySelectWidget(choices)
+        self.widget = widget if widget is not None else CurrencySelectWidget(choices)
 
         fields = (
             forms.DecimalField(

--- a/money/contrib/django/forms/widgets.py
+++ b/money/contrib/django/forms/widgets.py
@@ -6,16 +6,11 @@ class CurrencySelectWidget(forms.MultiWidget):
     Custom widget for entering a value and choosing a currency
     """
 
-    def __init__(self, choices=None, attrs=None, hide_currency=False):
+    def __init__(self, choices=None, attrs=None):
         widgets = (
             forms.TextInput(attrs=attrs),
+            forms.Select(attrs=attrs, choices=choices),
         )
-
-        if hide_currency:
-            widgets += (forms.HiddenInput(attrs=attrs),)
-        else:
-            widgets += (forms.Select(attrs=attrs, choices=choices),)
-
         super(CurrencySelectWidget, self).__init__(widgets, attrs)
 
     def decompress(self, value):

--- a/money/contrib/django/forms/widgets.py
+++ b/money/contrib/django/forms/widgets.py
@@ -6,11 +6,16 @@ class CurrencySelectWidget(forms.MultiWidget):
     Custom widget for entering a value and choosing a currency
     """
 
-    def __init__(self, choices=None, attrs=None):
+    def __init__(self, choices=None, attrs=None, hide_currency_select=False):
         widgets = (
             forms.TextInput(attrs=attrs),
-            forms.Select(attrs=attrs, choices=choices),
         )
+
+        if hide_currency_select:
+            widgets += (forms.HiddenInput(attrs=attrs),)
+        else:
+            widgets += (forms.Select(attrs=attrs, choices=choices),)
+
         super(CurrencySelectWidget, self).__init__(widgets, attrs)
 
     def decompress(self, value):

--- a/money/contrib/django/forms/widgets.py
+++ b/money/contrib/django/forms/widgets.py
@@ -6,12 +6,12 @@ class CurrencySelectWidget(forms.MultiWidget):
     Custom widget for entering a value and choosing a currency
     """
 
-    def __init__(self, choices=None, attrs=None, hide_currency_select=False):
+    def __init__(self, choices=None, attrs=None, hide_currency=False):
         widgets = (
             forms.TextInput(attrs=attrs),
         )
 
-        if hide_currency_select:
+        if hide_currency:
             widgets += (forms.HiddenInput(attrs=attrs),)
         else:
             widgets += (forms.Select(attrs=attrs, choices=choices),)


### PR DESCRIPTION
When rendering many forms with many `MoneyField` where the currency picker is hidden, the time it takes to process each hidden pickers for each field adds up and make some pages very slow to render.

In those cases where we don't care about selecting the currency but still want the validation to occur, it will use the given widget instead of the built-in `CurrencySelectWidget` to allow using a custom widget such as :
```
class HiddenCurrencyWidget(forms.MultiWidget):
    def __init__(self, attrs=None):
        widgets = (
            forms.TextInput(attrs=attrs),
            forms.HiddenInput(attrs=attrs),
        )
    def decompress(self, value):
        ...
```
By default it will use `CurrencySelectWidget`