### PR TITLE
Have the money field proxy descriptor behave properly

### DIFF
--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -58,6 +58,8 @@ class MoneyFieldProxy(object):
         obj.__dict__[self.field.currency_field_name] = currency
 
     def __get__(self, obj, *args):
+        if obj is None:
+            return self
         amount, currency = self._get_values(obj)
         if amount is None:
             return None


### PR DESCRIPTION
Generally, descriptors tend to return themselves when accessed through the class (That is to say, when the instance is `None`)