### PR TITLE
Replace deprecated _get_val_from_obj method

### DIFF
--- a/money/contrib/django/models/fields.py
+++ b/money/contrib/django/models/fields.py
@@ -128,7 +128,7 @@ class CurrencyField(models.CharField):
         When serializing, we want to output as two values. This will be just
         the currency part as stored directly in the database.
         """
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value
 
 
@@ -250,7 +250,7 @@ class MoneyField(InfiniteDecimalField):
         Here we only need to output the value. The contributed currency field
         will get called to output itself
         """
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value.amount
 
     def formfield(self, **kwargs):


### PR DESCRIPTION
This method has been long deprecated, and breaks some serialization functionality (e.g. running `manage.py dumpdata`). This PR replaces it with `value_from_object`, the functionality of which the old method duplicated.

Tested locally.