### PR TITLE
[Bug] Specify utf-8 encoding in version.py

### DIFF
--- a/version.py
+++ b/version.py
@@ -65,8 +65,12 @@ def call_git_describe(abbrev=5):
 
     """
     try:
-        p = Popen(['git', 'describe', '--long', '--tags', '--always',
-                   '--abbrev=%d' % abbrev], stdout=PIPE, stderr=PIPE)
+        p = Popen(
+            ['git', 'describe', '--long', '--tags', '--always', '--abbrev=%d' % abbrev],
+            stdout=PIPE,
+            stderr=PIPE,
+            encoding='utf-8',
+        )
         p.stderr.close()
         line = p.stdout.readlines()[0].strip()
 


### PR DESCRIPTION
With the recent update to `setuptools==70.0.0`, the module can no longer be installed in certain python environments. This is due to the `version.py` script not providing any output (`get_git_version()` returns `None`). `setuptools` versions prior to `setuptools==66.0.0` fell back to `packaging.version.LegacyVersion`, which would provide a PEP440 compliant version number if one wasn't provided. This was [removed in `setuptools==66`](https://github.com/pypa/setuptools/pull/2822).

This PR adds `encoding='utf-8'` to the `Popen` command in `version.py`, which puts `stderr` and `stdout` into text mode, returning a string rather than returning a bytestream when read. This prevents a `TypeError` being raised when `.strip()` is called on this output (the Exception - indeed, as with all exceptions - is silently caught by the try-except block).

Tested locally.